### PR TITLE
feat: Configure Maven publishing and refactor packages

### DIFF
--- a/.github/worikflows/publish.yml
+++ b/.github/worikflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to maven
+on:
+  push:
+    tags:
+      - '*' # Match any tag, e.g., 1.0.0
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+
+jobs:
+  publish:
+    name: Release build and publish
+    runs-on: macOS-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+
+      - name: Publish to Maven Central
+        env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY_BASE64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          TAG_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          ./gradlew publishToMavenCentral \
+            -Pversion=$TAG_VERSION \
+            -Dorg.gradle.project.signingInMemoryKey="$(echo "$GPG_KEY_BASE64" | base64 --decode)" \
+            -Dorg.gradle.project.signingInMemoryKeyPassword="$SIGNING_PASSWORD" \
+            -Dorg.gradle.project.mavenCentralUsername="$MAVEN_CENTRAL_USERNAME" \
+            -Dorg.gradle.project.mavenCentralPassword="$MAVEN_CENTRAL_PASSWORD" \
+            --stacktrace

--- a/composeApp/src/commonMain/kotlin/ke/don/ski/Deck.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/ski/Deck.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import ke.don.components.frames.defaultSkiFrames
+import io.github.donald_okara.components.frames.defaultSkiFrames
 import ke.don.design.theme.AppTheme
 import ke.don.domain.Slide
 import ke.don.navigation.DeckKeyHandler

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlin = "2.3.0"
 kotlinx-coroutines = "1.10.2"
 compose = "1.10.0-rc02"
 kotlinxSerializationCore = "1.9.0"
+vanniktech = "0.34.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -52,6 +53,7 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+maven-publishing = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech" }
 
 # Custom plugins
 composeMultiplatformPlugin = { id = "ke.don.ski.composeMultiplatformPlugin", version = "unspecified" }

--- a/segments/introduction/src/commonMain/kotlin/ke/don/introduction/IntroductionScreen.kt
+++ b/segments/introduction/src/commonMain/kotlin/ke/don/introduction/IntroductionScreen.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import ke.don.components.picture.BrushType
-import ke.don.components.picture.ExpressivePictureFrame
+import io.github.donald_okara.components.picture.BrushType
+import io.github.donald_okara.components.picture.ExpressivePictureFrame
 import ke.don.resources.Resources
 import org.jetbrains.compose.resources.DrawableResource
 

--- a/shared/components/build.gradle.kts
+++ b/shared/components/build.gradle.kts
@@ -1,14 +1,62 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatformLibrary)
     alias(libs.plugins.composeMultiplatformPlugin)
+    alias(libs.plugins.maven.publishing)
 }
 
-//kotlin {
-//    sourceSets{
-//        commonMain.dependencies {
-//            implementation(project(":shared:design"))
-//            implementation(project(":shared:resources"))
-//            implementation(project(":core:domain"))
-//        }
-//    }
-//}
+android {
+    namespace = "io.github.donald_okara"
+}
+
+
+mavenPublishing {
+    publishToMavenCentral() // or publishToMavenCentral(automaticRelease = true)
+    signAllPublications()
+
+    coordinates(group as String, "koffee", version as String)
+
+    pom {
+        name.set("Ski components library")
+        description.set("The components for the Ski slides template")
+        inceptionYear.set("2025")
+        url.set("https://github.com/donald-okara/ski/")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("donald-okara")
+                name.set("Donald Okara")
+                url.set("https://github.com/donald-okara/")
+            }
+        }
+        scm {
+            url.set("https://github.com/donald-okara/ski/")
+            connection.set("scm:git:git://github.com/donald-okara/ski.git")
+            developerConnection.set("scm:git:ssh://git@github.com/donald-okara/ski.git")
+        }
+    }
+}
+
+// ─── Dynamically infer tag version ─────────────────────────────────────────────
+
+val gitTagVersion: String by lazy {
+    try {
+        "git describe --tags --abbrev=0".runCommand()
+    } catch (e: Exception) {
+        "untagged"
+    }
+}
+
+fun String.runCommand(): String =
+    ProcessBuilder(*split(" ").toTypedArray())
+        .directory(rootDir)
+        .redirectErrorStream(true)
+        .start()
+        .inputStream
+        .bufferedReader()
+        .readText()

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/frames/DefaultSkiFrames.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/frames/DefaultSkiFrames.kt
@@ -1,4 +1,4 @@
-package ke.don.components.frames
+package io.github.donald_okara.components.frames
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/frames/SkiFrameDsl.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/frames/SkiFrameDsl.kt
@@ -1,13 +1,10 @@
-package ke.don.components.frames
+package io.github.donald_okara.components.frames
 
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.unit.Dp
 
 @Stable
 interface SkiFrame {

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/frames/SnakeFrame.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/frames/SnakeFrame.kt
@@ -1,4 +1,4 @@
-package ke.don.components.frames
+package io.github.donald_okara.components.frames
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -22,7 +22,7 @@ import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import ke.don.components.values.Values
+import io.github.donald_okara.components.values.Values
 
 class SnakeFrame(
     private val leftToRight: Boolean = true,

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/keys_shortcuts/KeyEventHandler.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/keys_shortcuts/KeyEventHandler.kt
@@ -1,4 +1,4 @@
-package ke.don.components.guides.keys_shortcuts
+package io.github.donald_okara.components.guides.keys_shortcuts
 
 import androidx.compose.ui.input.key.Key
 

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/keys_shortcuts/ShortcutsDictionary.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/keys_shortcuts/ShortcutsDictionary.kt
@@ -1,10 +1,9 @@
-package ke.don.components.guides.keys_shortcuts
+package io.github.donald_okara.components.guides.keys_shortcuts
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.unit.dp
-import ke.don.components.frames.SkiFrame
+import io.github.donald_okara.components.frames.SkiFrame
 
 @Composable
 fun ShortcutsDictionary(

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/layout/LazyScatterColumn.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/layout/LazyScatterColumn.kt
@@ -1,4 +1,4 @@
-package ke.don.components.layout
+package io.github.donald_okara.components.layout
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/picture/ExpressivePictureFrames.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/picture/ExpressivePictureFrames.kt
@@ -1,4 +1,4 @@
-package ke.don.components.picture
+package io.github.donald_okara.components.picture
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.InfiniteRepeatableSpec

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/values/Values.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/values/Values.kt
@@ -1,4 +1,4 @@
-package ke.don.components.values
+package io.github.donald_okara.components.values
 
 import androidx.compose.ui.unit.dp
 

--- a/shared/navigation/src/commonMain/kotlin/ke/don/navigation/DeckNavigator.kt
+++ b/shared/navigation/src/commonMain/kotlin/ke/don/navigation/DeckNavigator.kt
@@ -26,10 +26,10 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
-import ke.don.components.frames.SkiFrame
-import ke.don.components.guides.keys_shortcuts.DeckShortcuts
-import ke.don.components.guides.keys_shortcuts.KeyEventHandler
-import ke.don.components.guides.keys_shortcuts.ShortcutsDictionary
+import io.github.donald_okara.components.frames.SkiFrame
+import io.github.donald_okara.components.guides.keys_shortcuts.DeckShortcuts
+import io.github.donald_okara.components.guides.keys_shortcuts.KeyEventHandler
+import io.github.donald_okara.components.guides.keys_shortcuts.ShortcutsDictionary
 import ke.don.domain.NavDirection
 import ke.don.domain.Slide
 import kotlinx.coroutines.yield

--- a/shared/navigation/src/commonMain/kotlin/ke/don/navigation/MainContainer.kt
+++ b/shared/navigation/src/commonMain/kotlin/ke/don/navigation/MainContainer.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import ke.don.components.frames.SkiFrame
-import ke.don.components.values.Values
+import io.github.donald_okara.components.frames.SkiFrame
+import io.github.donald_okara.components.values.Values
 import ke.don.domain.NavDirection
 import ke.don.domain.Slide
 import ke.don.domain.ScreenTransition

--- a/shared/navigation/src/commonMain/kotlin/ke/don/navigation/ScaffoldComponents.kt
+++ b/shared/navigation/src/commonMain/kotlin/ke/don/navigation/ScaffoldComponents.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import ke.don.components.frames.SkiFrame
+import io.github.donald_okara.components.frames.SkiFrame
 import ke.don.domain.Slide
 
 @Composable


### PR DESCRIPTION
*   Changes package names from `ke.don` to `io.github.donald_okara`.
*   Adds the `com.vanniktech.maven.publish` plugin for deployment.
*   Configures `mavenPublishing` in the `:shared:components` module.
*   Adds a GitHub Actions workflow (`publish.yml`) to publish to Maven Central.