### PR TITLE
feat: Add segmented screen layouts and demos

### DIFF
--- a/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/SlideSwitcher.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/SlideSwitcher.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import io.github.donald_okara.components.guides.notes.Notes
 import ke.don.demos.ExampleSlide
+import ke.don.demos.HorizontalSegmentsDemo
 import ke.don.demos.KodeViewerSlide
+import ke.don.demos.VerticalSegmentsDemo
 import ke.don.domain.Slide
 import ke.don.introduction.IntroductionScreen
 
@@ -24,6 +26,8 @@ fun SlideSwitcher(
         Slide.Introduction -> IntroductionScreen(modifier)
         Slide.ExampleScreen -> ExampleSlide(modifier)
         Slide.KodeViewer -> KodeViewerSlide(modifier)
+        Slide.VerticalSegmentsDemo -> VerticalSegmentsDemo(modifier)
+        Slide.HorizontalSegmentsDemo -> HorizontalSegmentsDemo(modifier)
     }
 }
 

--- a/core/domain/src/commonMain/kotlin/ke/don/domain/Slide.kt
+++ b/core/domain/src/commonMain/kotlin/ke/don/domain/Slide.kt
@@ -27,7 +27,13 @@ sealed class Slide(
         label = "Kode Viewer",
     )
 
+    data object HorizontalSegmentsDemo: Slide(
+        label = "Horizontal Segments Demo",
+    )
 
+    data object VerticalSegmentsDemo: Slide(
+        label = "Vertical Segments Demo",
+    )
 
     fun index(): Int {
         return getScreens().indexOf(this)
@@ -38,7 +44,9 @@ sealed class Slide(
             listOf(
                 Introduction,
                 ExampleScreen,
-                KodeViewer
+                KodeViewer,
+                VerticalSegmentsDemo,
+                HorizontalSegmentsDemo
             )
     }
 }

--- a/segments/demos/src/commonMain/kotlin/ke/don/demos/SegmentedDemos.kt
+++ b/segments/demos/src/commonMain/kotlin/ke/don/demos/SegmentedDemos.kt
@@ -19,7 +19,7 @@ fun HorizontalSegmentsDemo(
 ) {
     HorizontallySegmentedScreen(
         modifier = modifier,
-        initialSegments = segments
+        initialSegments = segments,
     )
 }
 
@@ -29,7 +29,7 @@ fun VerticalSegmentsDemo(
 ) {
     VerticallySegmentedScreen(
         modifier = modifier,
-        initialSegments = segments
+        initialSegments = segments,
     )
 }
 val segments = listOf(
@@ -51,7 +51,7 @@ fun SegmentItem(
         footer = null,
     ) {
         Box(
-            modifier = modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ){
             Text(

--- a/segments/demos/src/commonMain/kotlin/ke/don/demos/SegmentedDemos.kt
+++ b/segments/demos/src/commonMain/kotlin/ke/don/demos/SegmentedDemos.kt
@@ -1,0 +1,64 @@
+package ke.don.demos
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.donald_okara.components.frames.defaultSkiFrames
+import io.github.donald_okara.components.layout.HorizontallySegmentedScreen
+import io.github.donald_okara.components.layout.VerticallySegmentedScreen
+
+@Composable
+fun HorizontalSegmentsDemo(
+    modifier: Modifier = Modifier,
+) {
+    HorizontallySegmentedScreen(
+        modifier = modifier,
+        initialSegments = segments
+    )
+}
+
+@Composable
+fun VerticalSegmentsDemo(
+    modifier: Modifier = Modifier,
+) {
+    VerticallySegmentedScreen(
+        modifier = modifier,
+        initialSegments = segments
+    )
+}
+val segments = listOf(
+    1f to @Composable { SegmentItem(index = 1) },
+    1f to @Composable { SegmentItem(index = 2) },
+    1f to @Composable { SegmentItem(index = 3) },
+)
+
+@Composable
+fun SegmentItem(
+    modifier: Modifier = Modifier,
+    index: Int
+) {
+    val frame = defaultSkiFrames().snake.create()
+    frame.Render(
+        modifier = modifier
+            .padding(16.dp),
+        header = null,
+        footer = null,
+    ) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ){
+            Text(
+                text = "Segment $index",
+                style = MaterialTheme.typography.titleLarge
+            )
+        }
+    }
+
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/layout/SegmentedScreens.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/layout/SegmentedScreens.kt
@@ -47,10 +47,7 @@ fun VerticallySegmentedScreen(
                     .weight(weights[index])
                     .fillMaxWidth()
             ) {
-                AnimatedContent(
-                    targetState = content,
-                    label = "Segment-$index"
-                ) { it() }
+                 content()
             }
 
             if (index < initialSegments.lastIndex && enableDrag) {
@@ -88,10 +85,7 @@ fun HorizontallySegmentedScreen(
                     .weight(weights[index])
                     .fillMaxHeight()
             ) {
-                AnimatedContent(
-                    targetState = content,
-                    label = "Segment-$index"
-                ) { it() }
+                content()
             }
 
             if (index < initialSegments.lastIndex && enableDrag) {

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/layout/SegmentedScreens.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/layout/SegmentedScreens.kt
@@ -1,0 +1,177 @@
+package io.github.donald_okara.components.layout
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun VerticallySegmentedScreen(
+    modifier: Modifier = Modifier,
+    initialSegments: List<Pair<Float, @Composable () -> Unit>>,
+    minWeight: Float = 0.5f,
+    enableDrag: Boolean = true
+) {
+    var weights by remember {
+        mutableStateOf(initialSegments.map { it.first })
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        initialSegments.forEachIndexed { index, (_, content) ->
+
+            Box(
+                modifier = Modifier
+                    .weight(weights[index])
+                    .fillMaxWidth()
+            ) {
+                AnimatedContent(
+                    targetState = content,
+                    label = "Segment-$index"
+                ) { it() }
+            }
+
+            if (index < initialSegments.lastIndex && enableDrag) {
+                VerticalDragHandle(
+                    onDrag = { delta ->
+                        weights = adjustWeights(
+                            weights = weights,
+                            index = index,
+                            delta = delta,
+                            minWeight = minWeight
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun HorizontallySegmentedScreen(
+    modifier: Modifier = Modifier,
+    initialSegments: List<Pair<Float, @Composable () -> Unit>>,
+    minWeight: Float = 0.5f,
+    enableDrag: Boolean = true
+) {
+    var weights by remember {
+        mutableStateOf(initialSegments.map { it.first })
+    }
+
+    Row(modifier = modifier.fillMaxSize()) {
+        initialSegments.forEachIndexed { index, (_, content) ->
+
+            Box(
+                modifier = Modifier
+                    .weight(weights[index])
+                    .fillMaxHeight()
+            ) {
+                AnimatedContent(
+                    targetState = content,
+                    label = "Segment-$index"
+                ) { it() }
+            }
+
+            if (index < initialSegments.lastIndex && enableDrag) {
+                HorizontalDragHandle { delta ->
+                    weights = adjustWeights(
+                        weights,
+                        index,
+                        delta,
+                        minWeight
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun adjustWeights(
+    weights: List<Float>,
+    index: Int,
+    delta: Float,
+    minWeight: Float
+): List<Float> {
+    val dragFactor = delta / 300f // controls sensitivity
+
+    val w1 = (weights[index] + dragFactor).coerceAtLeast(minWeight)
+    val w2 = (weights[index + 1] - dragFactor).coerceAtLeast(minWeight)
+
+    if (w1 + w2 <= minWeight * 2) return weights
+
+    return weights.toMutableList().apply {
+        this[index] = w1
+        this[index + 1] = w2
+    }
+}
+
+@Composable
+private fun VerticalDragHandle(
+    height: Dp = 12.dp,
+    onDrag: (Float) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(height)
+            .pointerInput(Unit) {
+                detectVerticalDragGestures { _, dragAmount ->
+                    onDrag(dragAmount)
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.DragHandle,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun HorizontalDragHandle(
+    width: Dp = 12.dp,
+    onDrag: (Float) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxHeight()
+            .width(width)
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures { _, dragAmount ->
+                    onDrag(dragAmount)
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.DragIndicator,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+


### PR DESCRIPTION
*   Introduces `VerticallySegmentedScreen` and `HorizontallySegmentedScreen` components with draggable handles for resizing segments.
*   Adds `VerticalSegmentsDemo` and `HorizontalSegmentsDemo` to the demo module.
*   Registers new segmented demo slides in the `Slide` domain model and `SlideSwitcher`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new demo screens: Horizontal Segments Demo and Vertical Segments Demo, showcasing resizable split-pane layouts with draggable dividers to adjust segment sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->