### PR TITLE
docs: Update terminology in README (closes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Build animated lists, counters, diagrams, and charts using Compose animation API
 Ski launches two synchronized windows:
 
 * **Presenter Panel** — Notes, table of contents, and keyboard shortcuts
-* **Presentation Surface** — Clean output intended for projection
+* **Slides** — Clean output intended for projection
 
 Both windows stay synchronized on the current slide index. Screen-specific animation state is intentionally isolated per window.
 


### PR DESCRIPTION
*   Renames "Presentation Surface" to "Slides" in the window descriptions for better clarity.
*   Maintains existing descriptions for synchronization and state isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Dual-Window Presenter Mode documentation with label changes for the second window output section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->