### PR TITLE
feat: add Whiteboard component and integration (closes #33)

### DIFF
--- a/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/ui/ScaffoldComponents.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/ui/ScaffoldComponents.kt
@@ -6,26 +6,24 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import io.github.donald_okara.components.frames.SkiFrame
+import io.github.donald_okara.components.guides.whiteboard.FocusWhiteboard
 import ke.don.design.theme.dimens
-import ke.don.domain.Slide
 
 @Composable
 fun ToolBar(
@@ -34,6 +32,10 @@ fun ToolBar(
     title: @Composable () -> Unit,
     onThemeClick: () -> Unit,
 ) {
+    var whiteboardValue by remember { mutableStateOf("") }
+    var showWhiteboard by remember { mutableStateOf(false) }
+    var isWhiteboardDark by remember { mutableStateOf(false) }
+
     Column(
         modifier = modifier
             .padding(
@@ -48,20 +50,34 @@ fun ToolBar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             title()
-            IconButton(
-                onClick = onThemeClick
-            ) {
-                Crossfade(targetState = darkTheme, label = "Theme icon crossfade") { isDark ->
-                    if (isDark) {
-                        Icon(
-                            imageVector = Icons.Default.LightMode,
-                            contentDescription = "Switch to Light Theme"
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Default.DarkMode,
-                            contentDescription = "Switch to Dark Theme"
-                        )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+            ){
+                IconButton(
+                    onClick = { showWhiteboard = true }
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = "Open Whiteboard"
+                    )
+                }
+
+                IconButton(
+                    onClick = onThemeClick
+                ) {
+                    Crossfade(targetState = darkTheme, label = "Theme icon crossfade") { isDark ->
+                        if (isDark) {
+                            Icon(
+                                imageVector = Icons.Default.LightMode,
+                                contentDescription = "Switch to Light Theme"
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.DarkMode,
+                                contentDescription = "Switch to Dark Theme"
+                            )
+                        }
                     }
                 }
             }
@@ -71,6 +87,17 @@ fun ToolBar(
             thickness = 4.dp,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 4.dp) //Nested padding is intentional here
+        )
+    }
+
+
+    if (showWhiteboard){
+        FocusWhiteboard(
+            onDismiss = { showWhiteboard = false },
+            darkTheme = isWhiteboardDark,
+            toggleTheme = { isWhiteboardDark = !isWhiteboardDark },
+            value = whiteboardValue,
+            onValueChange = { whiteboardValue = it }
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/ui/SkiPresentationSlides.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/ui/SkiPresentationSlides.kt
@@ -8,6 +8,7 @@ import ke.don.demos.ExampleSlide
 import ke.don.demos.HorizontalSegmentsDemo
 import ke.don.demos.KodeViewerSlide
 import ke.don.demos.VerticalSegmentsDemo
+import ke.don.demos.WhiteboardSlide
 import ke.don.domain.ScreenTransition
 import ke.don.introduction.IntroductionScreen
 import ke.don.ski.SlidesConstants.SESSION_DURATION
@@ -36,6 +37,9 @@ fun skiPresentationSlides(sessionDuration: Duration = SESSION_DURATION): List<Sl
                 }
                 slide("Kode Viewer") {
                     KodeViewerSlide()
+                }
+                slide("Whiteboard Screen"){
+                    WhiteboardSlide()
                 }
                 slide("Vertical Segments Demo") {
                     VerticalSegmentsDemo()

--- a/segments/demos/src/commonMain/kotlin/ke/don/demos/WhiteboardExample.kt
+++ b/segments/demos/src/commonMain/kotlin/ke/don/demos/WhiteboardExample.kt
@@ -11,8 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import io.github.donald_okara.components.guides.code_viewer.FocusKotlinViewer
-import io.github.donald_okara.components.guides.code_viewer.KotlinCodeViewerCard
 import io.github.donald_okara.components.guides.whiteboard.FocusWhiteboard
 import io.github.donald_okara.components.guides.whiteboard.WhiteboardCard
 

--- a/segments/demos/src/commonMain/kotlin/ke/don/demos/WhiteboardExample.kt
+++ b/segments/demos/src/commonMain/kotlin/ke/don/demos/WhiteboardExample.kt
@@ -1,0 +1,62 @@
+package ke.don.demos
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import io.github.donald_okara.components.guides.code_viewer.FocusKotlinViewer
+import io.github.donald_okara.components.guides.code_viewer.KotlinCodeViewerCard
+import io.github.donald_okara.components.guides.whiteboard.FocusWhiteboard
+import io.github.donald_okara.components.guides.whiteboard.WhiteboardCard
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun WhiteboardSlide(
+    modifier: Modifier = Modifier
+) {
+    var isCardDark by remember {
+        mutableStateOf(true)
+    }
+    var isFocusDark by remember {
+        mutableStateOf(true)
+    }
+    var isFocused by remember {
+        mutableStateOf(false)
+    }
+
+    var value by remember {
+       mutableStateOf("")
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        WhiteboardCard(
+            modifier = Modifier.fillMaxWidth(0.7f),
+            darkTheme = isCardDark,
+            toggleFocus = { isFocused = !isFocused },
+            toggleTheme = { isCardDark = !isCardDark },
+            value = value,
+            onValueChange = { value = it }
+        )
+    }
+
+    if (isFocused){
+        FocusWhiteboard(
+            onDismiss = { isFocused = false },
+            darkTheme = isFocusDark,
+            toggleTheme = { isFocusDark = !isFocusDark },
+            value = value,
+            onValueChange = { value = it }
+        )
+    }
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/FocusWhiteboard.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/FocusWhiteboard.kt
@@ -1,4 +1,4 @@
-package io.github.donald_okara.components.guides.code_viewer
+package io.github.donald_okara.components.guides.whiteboard
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Box
@@ -7,15 +7,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.DarkMode
 import androidx.compose.material.icons.outlined.LightMode
-import androidx.compose.material.icons.outlined.UnfoldLess
-import androidx.compose.material.icons.outlined.UnfoldMore
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -33,22 +29,23 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import io.github.donald_okara.components.guides.code_viewer.scaled
 import io.github.donald_okara.components.icon.IconButtonToken
 import io.github.donald_okara.components.values.Values
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FocusKotlinViewer(
-    modifier: Modifier = Modifier,
-    title: String = "Preview",
+fun FocusWhiteboard(
+    value: String,
+    onValueChange: (String) -> Unit,
     onDismiss: () -> Unit,
     darkTheme: Boolean,
     toggleTheme: () -> Unit,
-    code: () -> String
+    modifier: Modifier = Modifier,
+    title: String = "Whiteboard"
 ) {
     /* ---------- scale ---------- */
 
@@ -61,14 +58,10 @@ fun FocusKotlinViewer(
         label = "text-scale"
     )
 
-    /* ---------- folding ---------- */
-
-    var foldLambdas by rememberSaveable { mutableStateOf(false) }
-
     /* ---------- theme ---------- */
 
-    val targetTheme = if (darkTheme) CodeThemes.Dark else CodeThemes.Light
-    val colorScheme = animateCodeTheme(targetTheme)
+    val targetTheme = if (darkTheme) WhiteboardThemes.Dark else WhiteboardThemes.Light
+    val colorScheme = animateWhiteboardTheme(targetTheme)
 
     /* ---------- dialog ---------- */
 
@@ -109,18 +102,6 @@ fun FocusKotlinViewer(
                         }
                     },
                     actions = {
-
-                        IconButtonToken(
-                            icon = if (foldLambdas)
-                                Icons.Outlined.UnfoldMore
-                            else
-                                Icons.Outlined.UnfoldLess,
-                            contentDescription = "Fold Lambdas",
-                            accentColor = colorScheme.normal,
-                            sizeInt = 36,
-                            onClick = { foldLambdas = !foldLambdas }
-                        )
-
                         IconButtonToken(
                             icon = if (darkTheme)
                                 Icons.Outlined.LightMode
@@ -169,30 +150,16 @@ fun FocusKotlinViewer(
                 Box(
                     modifier = modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
                         .padding(16.dp)
                 ) {
-                    KotlinCodeViewer(
-                        code = code(),
-                        codeTheme = colorScheme,
-                        textScale = animatedScale,
-                        shouldFoldLambdas = foldLambdas,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(Values.Dimens.mediumPadding)
+                    WhiteboardComponent(
+                        value = value,
+                        onValueChange = onValueChange,
+                        whiteboardTheme = colorScheme,
+                        textScale = animatedScale
                     )
                 }
             }
         }
     }
 }
-
-
-
-fun TextStyle.scaled(scale: Float): TextStyle {
-    return copy(
-        fontSize = fontSize * scale,
-        lineHeight = lineHeight * scale
-    )
-}
-

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/Helpers.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/Helpers.kt
@@ -1,0 +1,70 @@
+package io.github.donald_okara.components.guides.whiteboard
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.withStyle
+
+fun highlightWhiteboard(
+    text: String,
+    theme: WhiteboardTheme
+): AnnotatedString {
+    val builder = AnnotatedString.Builder()
+
+    val urlPattern = "(https?://[\\w./?=&-]+)".toRegex()
+    val boldPattern = "\\*\\*(.*?)\\*\\*".toRegex()
+    val italicPattern = "_(.*?)_".toRegex()
+    val strikePattern = "~~(.*?)~~".toRegex()
+
+    val matches = buildList {
+        addAll(urlPattern.findAll(text))
+        addAll(boldPattern.findAll(text))
+        addAll(italicPattern.findAll(text))
+        addAll(strikePattern.findAll(text))
+    }.sortedBy { it.range.first }
+        .fold(mutableListOf<MatchResult>()) { acc, match ->
+            if (acc.none { it.range.overlaps(match.range) }) acc.add(match)
+            acc
+        }
+
+    var index = 0
+
+    for (match in matches) {
+        if (match.range.first > index) {
+            builder.withStyle(SpanStyle(color = theme.normal)) {
+                append(text.substring(index, match.range.first))
+            }
+        }
+
+        val style = when {
+            urlPattern.matches(match.value) -> SpanStyle(color = theme.link)
+            boldPattern.matches(match.value) -> SpanStyle(fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+            italicPattern.matches(match.value) -> SpanStyle(fontStyle = androidx.compose.ui.text.font.FontStyle.Italic)
+            strikePattern.matches(match.value) -> SpanStyle(textDecoration = androidx.compose.ui.text.style.TextDecoration.LineThrough)
+            else -> SpanStyle(color = theme.normal)
+        }
+
+        builder.withStyle(style) {
+            // For Markdown-like patterns, we might want to strip the symbols
+            val content = when {
+                boldPattern.matches(match.value) -> match.groupValues[1]
+                italicPattern.matches(match.value) -> match.groupValues[1]
+                strikePattern.matches(match.value) -> match.groupValues[1]
+                else -> match.value
+            }
+            append(content)
+        }
+
+        index = match.range.last + 1
+    }
+
+    if (index < text.length) {
+        builder.withStyle(SpanStyle(color = theme.normal)) {
+            append(text.substring(index))
+        }
+    }
+
+    return builder.toAnnotatedString()
+}
+
+fun IntRange.overlaps(other: IntRange): Boolean =
+    this.first <= other.last && other.first <= this.last

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/WhiteboardComponent.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/WhiteboardComponent.kt
@@ -1,0 +1,203 @@
+package io.github.donald_okara.components.guides.whiteboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.outlined.DarkMode
+import androidx.compose.material.icons.outlined.LightMode
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.dp
+import io.github.donald_okara.components.guides.code_viewer.scaled
+import io.github.donald_okara.components.icon.IconButtonToken
+import io.github.donald_okara.components.values.Values
+
+@Composable
+fun WhiteboardCard(
+    value: String,
+    onValueChange: (String) -> Unit,
+    toggleFocus: () -> Unit = {},
+    toggleTheme: () -> Unit = {},
+    modifier: Modifier = Modifier,
+    darkTheme: Boolean = true,
+
+    ) {
+    val targetTheme = if (darkTheme) {
+        WhiteboardThemes.Dark
+    } else {
+        WhiteboardThemes.Light
+    }
+
+    val colorScheme = animateWhiteboardTheme(targetTheme)
+    Surface(
+        shape = RoundedCornerShape(Values.cornerRadius),
+        tonalElevation = 1.dp,
+        color = colorScheme.background,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                IconButtonToken(
+                    icon = Icons.Default.Fullscreen,
+                    accentColor = colorScheme.normal,
+                    contentDescription = "Toggle Fullscreen",
+                    sizeInt = 48,
+                    onClick = toggleFocus
+                )
+
+                IconButtonToken(
+                    icon = if (darkTheme) {
+                        Icons.Outlined.LightMode
+                    } else {
+                        Icons.Outlined.DarkMode
+                    },
+                    contentDescription = "Toggle Theme",
+                    accentColor = colorScheme.normal,
+                    sizeInt = 48,
+                    onClick = toggleTheme
+                )
+
+            }
+
+            WhiteboardComponent(
+                darkTheme = darkTheme,
+                whiteboardTheme = colorScheme,
+                value = value,
+                onValueChange = onValueChange,
+            )
+        }
+    }
+}
+
+@Composable
+fun WhiteboardComponent(
+    modifier: Modifier = Modifier,
+    darkTheme: Boolean = true,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String = "Start writing...",
+    whiteboardTheme: WhiteboardTheme = if (darkTheme) {
+        WhiteboardThemes.Dark
+    } else {
+        WhiteboardThemes.Light
+    },
+    textScale: Float = 0.75f,
+) {
+    val scrollState = rememberScrollState()
+
+    Surface(
+        tonalElevation = 1.dp,
+        color = whiteboardTheme.background,
+        modifier = modifier
+            .fillMaxSize()
+            .padding(
+                vertical = Values.Dimens.tinyPadding,
+                horizontal = Values.Dimens.smallPadding
+            ),
+    ) {
+        SelectionContainer {
+            BasicTextField(
+                modifier = Modifier
+                    .verticalScroll(scrollState)
+                    .fillMaxSize(),
+                value = value,
+                cursorBrush = SolidColor(whiteboardTheme.normal),
+                onValueChange = onValueChange,
+                textStyle = MaterialTheme.typography
+                    .bodyLarge
+                    .scaled(textScale)
+                    .copy(color = Color.Transparent),
+                decorationBox = { innerTextField ->
+                    DecoratorBox(value, textScale, whiteboardTheme, placeholder, innerTextField)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun DecoratorBox(
+    value: String,
+    textScale: Float,
+    whiteboardTheme: WhiteboardTheme,
+    placeholder: String,
+    innerTextField: @Composable (() -> Unit)
+) {
+    Row(modifier = Modifier.fillMaxSize()) {
+
+        // Line numbers
+        Column(
+            modifier = Modifier.padding(end = 12.dp),
+            verticalArrangement = Arrangement.Top
+        ) {
+            val lineCount = value.lines().size.coerceAtLeast(1)
+            repeat(lineCount) { index ->
+                Text(
+                    text = "${index + 1}.",
+                    style = MaterialTheme.typography.bodyLarge
+                        .scaled(textScale)
+                        .copy(
+                            color = whiteboardTheme.normal.copy(alpha = 0.4f)
+                        )
+                )
+            }
+        }
+
+        Box(modifier = Modifier.weight(1f)) {
+
+            // Placeholder
+            if (value.isEmpty()) {
+                Text(
+                    text = placeholder,
+                    style = MaterialTheme.typography.bodyLarge
+                        .scaled(textScale)
+                        .copy(
+                            color = whiteboardTheme.normal.copy(alpha = 0.3f)
+                        )
+                )
+            }
+
+            // Highlight links
+            val annotatedText = remember(value, whiteboardTheme) {
+                highlightWhiteboard(
+                    text = value,
+                    theme = whiteboardTheme
+                )
+            }
+
+            innerTextField()
+
+            // Overlay the styled text
+            Text(
+                text = annotatedText,
+                style = MaterialTheme.typography.bodyLarge
+                    .scaled(textScale)
+                    .copy(color = whiteboardTheme.normal)
+            )
+        }
+    }
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/WhiteboardTheme.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/guides/whiteboard/WhiteboardTheme.kt
@@ -1,0 +1,37 @@
+package io.github.donald_okara.components.guides.whiteboard
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class WhiteboardTheme(
+    val background: Color,
+    val normal: Color,
+    val link: Color,
+)
+
+object WhiteboardThemes {
+
+    val Dark = WhiteboardTheme(
+        background = Color(0xFF1E1E1E),
+        normal = Color(0xFFD4D4D4),
+        link = Color(0xFF569CD6),
+    )
+
+    val Light = WhiteboardTheme(
+        background = Color(0xFFF5F5F5),
+        normal = Color(0xFF1E1E1E),
+        link = Color(0xFF0000FF),
+    )
+}
+
+@Composable
+fun animateWhiteboardTheme(target: WhiteboardTheme): WhiteboardTheme {
+    return WhiteboardTheme(
+        background = animateColorAsState(target.background, label = "bg").value,
+        normal = animateColorAsState(target.normal, label = "normal").value,
+        link = animateColorAsState(target.link, label = "keyword").value,
+    )
+}


### PR DESCRIPTION
*   Introduces `FocusWhiteboard`, `WhiteboardCard`, and `WhiteboardComponent` for interactive text editing and display.
*   Adds support for theme switching (light/dark) and text scaling within the whiteboard components.
*   Implements basic Markdown-like highlighting for URLs, bold, italic, and strikethrough text in `highlightWhiteboard`.
*   Integrates a global whiteboard access button into the `ToolBar` within `ScaffoldComponents.kt`.
*   Adds a new `WhiteboardSlide` demo and registers it in the presentation slide list.
*   Updates `FocusKotlinViewer` to support a customizable title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive whiteboard editor with focus (overlay) mode and toggleable dark/light themes
  * Adjustable text scaling and formatted text support (links, bold, italic, strikethrough)
  * Toolbar quick-action to open the whiteboard and a new demo slide showcasing it
  * Whiteboard card/component for inline editing and fullscreen focus

* **New Options**
  * Preview viewer title is now customizable via a new title parameter
<!-- end of auto-generated comment: release notes by coderabbit.ai -->