### PR TITLE
feat: add `DeviceFrame` component and `DeviceGallery` demo

### DIFF
--- a/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/ui/SkiPresentationSlides.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/ski/presentation/ui/SkiPresentationSlides.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import io.github.donald_okara.components.timer.TimerController
+import ke.don.demos.DeviceGallery
 import ke.don.demos.ExampleSlide
 import ke.don.demos.HorizontalSegmentsDemo
 import ke.don.demos.KodeViewerSlide
@@ -46,6 +47,9 @@ fun skiPresentationSlides(sessionDuration: Duration = SESSION_DURATION): List<Sl
                 }
                 slide("Horizontal Segments Demo") {
                     HorizontalSegmentsDemo()
+                }
+                slide("Device Frames"){
+                    DeviceGallery()
                 }
             }
         }

--- a/segments/demos/src/commonMain/kotlin/ke/don/demos/DeviceGallery.kt
+++ b/segments/demos/src/commonMain/kotlin/ke/don/demos/DeviceGallery.kt
@@ -1,0 +1,152 @@
+package ke.don.demos
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.github.donald_okara.components.devices.DeviceCatalog
+import io.github.donald_okara.components.devices.DeviceFrame
+import io.github.donald_okara.components.devices.DeviceOrientation
+import io.github.donald_okara.components.devices.DeviceSpec
+
+@Composable
+fun DeviceGallery() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(48.dp)
+    ) {
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            contentPadding = PaddingValues(horizontal = 16.dp)
+        ) {
+            item {
+                DeviceItem("Google Pixel 8", DeviceCatalog.Pixel8)
+            }
+            item {
+                DeviceItem("Samsung Galaxy S26", DeviceCatalog.GalaxyS26)
+            }
+            item {
+                DeviceItem("iPhone 17 Pro", DeviceCatalog.IPhone17)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeviceItem(name: String, spec: DeviceSpec) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        var orientation by remember {
+            mutableStateOf(DeviceOrientation.PORTRAIT)
+        }
+        DeviceControls(
+            orientation = orientation,
+            onOrientationChange = {
+                orientation = it
+            }
+        )
+
+        DeviceFrame(
+            spec = spec.copy(
+                orientation = orientation
+            ),
+            modifier = Modifier.height(500.dp)
+        ) {
+            DemoScreen()
+        }
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = Color.Gray
+        )
+    }
+}
+
+@Composable
+fun DemoScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(Color(0xFF6200EE), Color(0xFF3700B3))
+                )
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            "App Preview",
+            color = Color.White,
+            style = MaterialTheme.typography.labelLarge
+        )
+    }
+}
+
+@Composable
+fun DeviceControls(
+    orientation: DeviceOrientation,
+    onOrientationChange: (DeviceOrientation) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val options = listOf(
+        DeviceOrientation.PORTRAIT to "Portrait",
+        DeviceOrientation.LANDSCAPE to "Landscape"
+    )
+
+    Row(
+        modifier = modifier.padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        options.forEach { (value, label) ->
+            val isSelected = value == orientation
+
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(
+                        if (isSelected) Color.Black else Color.LightGray.copy(alpha = 0.3f)
+                    )
+                    .clickable { onOrientationChange(value) }
+                    .padding(horizontal = 16.dp, vertical = 10.dp)
+            ) {
+                Text(
+                    text = label,
+                    color = if (isSelected) Color.White else Color.Black
+                )
+            }
+        }
+    }
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceCatalog.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceCatalog.kt
@@ -1,0 +1,68 @@
+package io.github.donald_okara.components.devices
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+object DeviceCatalog {
+
+    val Pixel8 = DeviceSpec(
+        name = "Pixel 8",
+        aspectRatio = 20f / 9f,
+        cutout = CutoutSpec(
+            type = CutoutType.CENTER_CIRCLE,
+            size = 10.dp,
+            offsetY = 12.dp
+        ),
+        bezel = BezelSpec(
+            thickness = 14.dp,
+            color = Color(0xFF1F1F1F),
+            cornerRadius = 32.dp
+        ),
+        buttons = listOf(
+            ButtonSpec(ButtonSide.RIGHT, offset = (-100).dp, length = 30.dp), // Power
+            ButtonSpec(ButtonSide.RIGHT, offset = (-40).dp, length = 60.dp)   // Volume
+        )
+    )
+
+    val GalaxyS26 = DeviceSpec(
+        name = "Galaxy S26",
+        aspectRatio = 19.5f / 9f,
+        bezel = BezelSpec(
+            thickness = 10.dp,
+            color = Color(0xFF121212),
+            cornerRadius = 28.dp
+        ),
+        cutout = CutoutSpec(
+            type = CutoutType.CENTER_CIRCLE,
+            size = 8.dp,
+            offsetY = 10.dp
+        ),
+        buttons = listOf(
+            ButtonSpec(ButtonSide.RIGHT, offset = (-60).dp, length = 40.dp), // Power
+            ButtonSpec(ButtonSide.RIGHT, offset = 40.dp, length = 80.dp)    // Volume
+        )
+    )
+
+    val IPhone17 = DeviceSpec(
+        name = "iPhone 17",
+        aspectRatio = 19.5f / 9f,
+        bezel = BezelSpec(
+            thickness = 12.dp,
+            color = Color(0xFF1A1A1A),
+            cornerRadius = 36.dp
+        ),
+        notch = NotchSpec(
+            type = NotchType.DETACHED,
+            widthFraction = 0.35f,
+            height = 30.dp,
+            offset = 8.dp,
+            cornerRadius = 16.dp
+        ),
+        buttons = listOf(
+            ButtonSpec(ButtonSide.LEFT, offset = (-100).dp, length = 20.dp), // Mute/Action
+            ButtonSpec(ButtonSide.LEFT, offset = (-40).dp, length = 45.dp),  // Vol Up
+            ButtonSpec(ButtonSide.LEFT, offset = 20.dp, length = 45.dp),    // Vol Down
+            ButtonSpec(ButtonSide.RIGHT, offset = (-40).dp, length = 70.dp)  // Side button
+        )
+    )
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceFrame.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceFrame.kt
@@ -1,0 +1,304 @@
+package io.github.donald_okara.components.devices
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DeviceFrame(
+    spec: DeviceSpec,
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit
+) {
+    val isPortrait = spec.orientation == DeviceOrientation.PORTRAIT
+    
+    // The base ratio is always Portrait (e.g., 9/19.5)
+    val baseRatio = 1f / spec.aspectRatio
+    
+    // The visual ratio changes based on orientation to take up correct layout space
+    val targetVisualRatio = if (isPortrait) baseRatio else spec.aspectRatio
+    val visualRatio by animateFloatAsState(
+        targetValue = targetVisualRatio,
+        animationSpec = tween(durationMillis = 500)
+    )
+
+    val rotation by animateFloatAsState(
+        targetValue = if (isPortrait) 0f else -90f,
+        animationSpec = tween(durationMillis = 500)
+    )
+
+    LookaheadScope {
+        BoxWithConstraints(
+            modifier = modifier
+                .padding(horizontal = 48.dp)
+                .aspectRatio(visualRatio)
+        ) {
+            // Adaptive scaling: reference phone width is ~360dp
+            // In Landscape, the phone's 'width' is the container's height.
+            val phoneWidth = if (isPortrait) maxWidth else maxHeight
+            val scalingFactor = (phoneWidth / 360.dp).coerceAtLeast(0.1f)
+
+            // Animate insets to match rotation and scale
+            val baseInsets = spec.calculateInsets()
+            val animatedInsets = DeviceInsets(
+                top = animateDpAsState(baseInsets.top * scalingFactor, tween(500)).value,
+                bottom = animateDpAsState(baseInsets.bottom * scalingFactor, tween(500)).value,
+                start = animateDpAsState(baseInsets.start * scalingFactor, tween(500)).value,
+                end = animateDpAsState(baseInsets.end * scalingFactor, tween(500)).value
+            )
+
+            // Chassis Box
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .rotate(rotation)
+                    .then(
+                        // When Landscape, we need to swap constraints so the Portrait chassis
+                        // fills the Landscape outer container before it is rotated.
+                        if (isPortrait) Modifier.fillMaxSize()
+                        else Modifier.layout { measurable, constraints ->
+                            val placeable = measurable.measure(
+                                constraints.copy(
+                                    minWidth = constraints.maxHeight,
+                                    maxWidth = constraints.maxHeight,
+                                    minHeight = constraints.maxWidth,
+                                    maxHeight = constraints.maxWidth
+                                )
+                            )
+                            layout(constraints.maxWidth, constraints.maxHeight) {
+                                placeable.placeRelative(
+                                    (constraints.maxWidth - placeable.width) / 2,
+                                    (constraints.maxHeight - placeable.height) / 2
+                                )
+                            }
+                        }
+                    )
+            ) {
+                // External Buttons
+                spec.buttons.forEach { button ->
+                    DeviceButton(button, scalingFactor)
+                }
+
+                // Main Body (Chassis)
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .shadow(
+                            elevation = 12.dp * scalingFactor,
+                            shape = RoundedCornerShape(spec.bezel.cornerRadius * scalingFactor)
+                        )
+                        .background(
+                            brush = Brush.linearGradient(
+                                colors = listOf(
+                                    spec.bezel.color,
+                                    spec.bezel.color.copy(alpha = 0.85f),
+                                    spec.bezel.color
+                                )
+                            ),
+                            shape = RoundedCornerShape(spec.bezel.cornerRadius * scalingFactor)
+                        )
+                        .border(
+                            width = 1.dp * scalingFactor,
+                            color = Color.White.copy(alpha = 0.15f),
+                            shape = RoundedCornerShape(spec.bezel.cornerRadius * scalingFactor)
+                        )
+                        .padding(spec.bezel.thickness * scalingFactor)
+                ) {
+
+                    // Screen Area
+                    CompositionLocalProvider(
+                        LocalDeviceInsets provides animatedInsets
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(spec.screenCornerRadius * scalingFactor))
+                                .background(spec.screenColor)
+                                .border(
+                                    width = 1.dp * scalingFactor,
+                                    color = Color.Black.copy(alpha = 0.15f),
+                                    shape = RoundedCornerShape(spec.screenCornerRadius * scalingFactor)
+                                )
+                        ) {
+                            // Counter-rotate and re-layout the content to fill the screen
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .rotate(-rotation)
+                                    .then(
+                                        if (!isPortrait) Modifier.layout { measurable, constraints ->
+                                            val placeable = measurable.measure(
+                                                constraints.copy(
+                                                    minWidth = constraints.maxHeight,
+                                                    maxWidth = constraints.maxHeight,
+                                                    minHeight = constraints.maxWidth,
+                                                    maxHeight = constraints.maxWidth
+                                                )
+                                            )
+                                            layout(constraints.maxWidth, constraints.maxHeight) {
+                                                placeable.placeRelative(
+                                                    (constraints.maxWidth - placeable.width) / 2,
+                                                    (constraints.maxHeight - placeable.height) / 2
+                                                )
+                                            }
+                                        } else Modifier
+                                    )
+                            ) {
+                                content()
+                            }
+                        }
+                    }
+
+                    // Notch & Cutout
+                    if (spec.notch.type != NotchType.NONE) {
+                        Notch(spec.notch, scalingFactor)
+                    }
+                    Cutout(spec.cutout, scalingFactor)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.DeviceButton(spec: ButtonSpec, scale: Float) {
+    val alignment = when (spec.side) {
+        ButtonSide.LEFT -> Alignment.CenterStart
+        ButtonSide.RIGHT -> Alignment.CenterEnd
+        ButtonSide.TOP -> Alignment.TopCenter
+        ButtonSide.BOTTOM -> Alignment.BottomCenter
+    }
+
+    val thickness = spec.thickness * scale
+    val length = spec.length * scale
+    val offset = spec.offset * scale
+
+    val modifier = when (spec.side) {
+        ButtonSide.LEFT, ButtonSide.RIGHT -> {
+            Modifier
+                .align(alignment)
+                .offset(
+                    x = if (spec.side == ButtonSide.LEFT) (-thickness) else thickness,
+                    y = offset
+                )
+                .width(thickness)
+                .height(length)
+        }
+        ButtonSide.TOP, ButtonSide.BOTTOM -> {
+            Modifier
+                .align(alignment)
+                .offset(
+                    x = offset,
+                    y = if (spec.side == ButtonSide.TOP) (-thickness) else thickness
+                )
+                .width(length)
+                .height(thickness)
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .background(
+                color = spec.color,
+                shape = RoundedCornerShape(2.dp * scale)
+            )
+    )
+}
+
+@Composable
+private fun BoxScope.Notch(spec: NotchSpec, scale: Float) {
+    val topOffset = (when (spec.type) {
+        NotchType.ATTACHED -> 0.dp
+        NotchType.DETACHED -> spec.offset
+        else -> 0.dp
+    }) * scale
+
+    Box(
+        modifier = Modifier
+            .align(Alignment.TopCenter)
+            .padding(top = topOffset)
+            .fillMaxWidth(spec.widthFraction)
+            .height(spec.height * scale)
+            .background(
+                color = spec.color,
+                shape = RoundedCornerShape(spec.cornerRadius * scale)
+            )
+    ) {
+        // Subtle speaker grill
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth(0.35f)
+                .height(3.dp * scale)
+                .background(Color.White.copy(alpha = 0.1f), CircleShape)
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.Cutout(spec: CutoutSpec, scale: Float) {
+    if (spec.type == CutoutType.NONE) return
+
+    val size = spec.size * scale
+    val offsetY = spec.offsetY * scale
+
+    when (spec.type) {
+        CutoutType.CENTER_CIRCLE -> {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = offsetY)
+                    .size(size)
+                    .background(
+                        brush = Brush.radialGradient(
+                            colors = listOf(Color(0xFF1A1A1A), Color.Black)
+                        ),
+                        shape = CircleShape
+                    )
+                    .border(0.5.dp * scale, Color.White.copy(alpha = 0.1f), CircleShape)
+            )
+        }
+
+        CutoutType.PILL -> {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = offsetY)
+                    .height(size)
+                    .fillMaxWidth(0.18f)
+                    .background(
+                        color = Color.Black,
+                        shape = RoundedCornerShape(percent = 50)
+                    )
+            )
+        }
+    }
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceInsets.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceInsets.kt
@@ -1,6 +1,8 @@
 package io.github.donald_okara.components.devices
 
+import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -14,16 +16,16 @@ data class DeviceInsets(
     val end: Dp = 0.dp
 )
 
-val LocalDeviceInsets = staticCompositionLocalOf {
+val LocalDeviceInsets = compositionLocalOf {
     DeviceInsets()
 }
 
 fun Modifier.deviceSafePadding(): Modifier = composed {
     val insets = LocalDeviceInsets.current
-    this.padding(
+    this.absolutePadding(
         top = insets.top,
         bottom = insets.bottom,
-        start = insets.start,
-        end = insets.end
+        left = insets.start,
+        right = insets.end
     )
 }

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceInsets.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceInsets.kt
@@ -1,0 +1,29 @@
+package io.github.donald_okara.components.devices
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+data class DeviceInsets(
+    val top: Dp = 0.dp,
+    val bottom: Dp = 0.dp,
+    val start: Dp = 0.dp,
+    val end: Dp = 0.dp
+)
+
+val LocalDeviceInsets = staticCompositionLocalOf {
+    DeviceInsets()
+}
+
+fun Modifier.deviceSafePadding(): Modifier = composed {
+    val insets = LocalDeviceInsets.current
+    this.padding(
+        top = insets.top,
+        bottom = insets.bottom,
+        start = insets.start,
+        end = insets.end
+    )
+}

--- a/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceSpec.kt
+++ b/shared/components/src/commonMain/kotlin/io/github/donald_okara/components/devices/DeviceSpec.kt
@@ -1,0 +1,87 @@
+package io.github.donald_okara.components.devices
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+data class DeviceSpec(
+    val name: String,
+    val aspectRatio: Float = 19.5f / 9f,
+    val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
+    val bezel: BezelSpec = BezelSpec(),
+    val notch: NotchSpec = NotchSpec(),
+    val screenColor: Color = Color.White,
+    val cutout: CutoutSpec = CutoutSpec(),
+    val screenCornerRadius: Dp = 24.dp,
+    val buttons: List<ButtonSpec> = emptyList()
+){
+    /**
+     * The raw size of the logical top inset (notch or cutout).
+     */
+    val rawTopInset: Dp
+        get() = when {
+            notch.type == NotchType.ATTACHED -> notch.height
+            notch.type == NotchType.DETACHED -> notch.height + notch.offset
+            cutout.type != CutoutType.NONE -> cutout.size + cutout.offsetY
+            else -> 0.dp
+        }
+
+    fun calculateInsets(): DeviceInsets {
+        val inset = rawTopInset
+        return if (orientation == DeviceOrientation.PORTRAIT) {
+            DeviceInsets(top = inset)
+        } else {
+            // When rotated -90deg (Clockwise), logical top moves to visual Right (End)
+            DeviceInsets(end = inset)
+        }
+    }
+}
+
+enum class DeviceOrientation {
+    PORTRAIT, LANDSCAPE
+}
+
+enum class NotchType {
+    NONE,
+    ATTACHED,
+    DETACHED
+}
+
+data class NotchSpec(
+    val type: NotchType = NotchType.NONE,
+    val widthFraction: Float = 0.4f,
+    val height: Dp = 28.dp,
+    val offset: Dp = 8.dp,
+    val cornerRadius: Dp = 12.dp,
+    val color: Color = Color.Black
+)
+
+data class BezelSpec(
+    val thickness: Dp = 12.dp,
+    val color: Color = Color.Black,
+    val cornerRadius: Dp = 32.dp
+)
+
+enum class CutoutType {
+    NONE,
+    CENTER_CIRCLE,
+    PILL
+}
+
+data class CutoutSpec(
+    val type: CutoutType = CutoutType.NONE,
+    val size: Dp = 12.dp,
+    val offsetY: Dp = 10.dp
+)
+
+data class ButtonSpec(
+    val side: ButtonSide,
+    val offset: Dp,
+    val length: Dp,
+    val thickness: Dp = 3.dp,
+    val color: Color = Color.DarkGray
+)
+
+enum class ButtonSide {
+    LEFT, RIGHT, TOP, BOTTOM
+}


### PR DESCRIPTION
*   Introduces `DeviceFrame` and `DeviceSpec` to render customizable hardware frames (bezels, notches, cutouts, and buttons).
*   Adds `DeviceInsets` and `LocalDeviceInsets` for handling safe area padding across different device orientations.
*   Implements `DeviceCatalog` with predefined specifications for Pixel 8, Galaxy S26, and iPhone 17.
*   Adds `DeviceGallery` to the demo suite, allowing real-time orientation switching between portrait and landscape modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a device gallery component displaying multiple device models with interactive portrait/landscape orientation controls.
  * Introduced a new presentation slide showcasing device frames.
  * Device frames now render with realistic visual details (bezels, notches, cutouts) and animated orientation handling.
  * Pre-configured device models available for display.
  * Added safe inset handling so screen content respects device-specific notches/cutouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->